### PR TITLE
Lottie Version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
         .package(
             name: "Lottie",
             url: "https://github.com/airbnb/lottie-ios",
-            .upToNextMajor(from: "4.2.0")
+            exact: 4.4.0
         )
     ],
     targets: [


### PR DESCRIPTION
Lottie's deployment target was updated to iOS 13.0, and the dependency in version 4.4.2 is incompatible with Zowie SDK's deployment target.