### PR TITLE
update lottie to latest version with iOS 11 support

### DIFF
--- a/ZowieSDK.podspec
+++ b/ZowieSDK.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
 
   spec.name         = "ZowieSDK"
-  spec.version      = "0.0.18"
+  spec.version      = "0.0.19"
   spec.summary      = "Zowie chat SDK."
 
   spec.homepage     = "https://docs.getzowie.com"
@@ -32,7 +32,7 @@ Pod::Spec.new do |spec|
   spec.dependency "Apollo", "~> 0.49.1"
   spec.dependency "Apollo/WebSocket", "~> 0.49.1"
   spec.dependency "Kingfisher", "~> 7.0"
-  spec.dependency "lottie-ios", "~> 4.2.0"
+  spec.dependency "lottie-ios", "4.4.1"
 
 end
 


### PR DESCRIPTION
Hi, I think it will need some additional work on your side because I got runtime error when I start app with newer lottie version:
 _Symbol not found: _$s6Lottie19DefaultTextProviderCAA09AnimationcD0AAWP_
