### PR TITLE
Use lottie-spm instead of larger lottie-ios

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         ),
         .package(
             name: "Lottie",
-            url: "https://github.com/airbnb/lottie-ios",
+            url: "https://github.com/airbnb/lottie-spm",
             .exact("4.4.1")
         )
     ],


### PR DESCRIPTION
Hi, I've got two feature requests:
1. Could you use lottie-spm instead of much larger lottie-ios?
2. Can you please merge the `spm` branch into `main` so it's available for wider use?

Alternatively, could you consider removing the Lottie dependency at all if possible? I see a couple of other active PRs in the repo and they all concern Lottie. This is problematic because I'd like to use the version of Lottie I need in my app and not the one Zowie requires me to use. I would hope you agree that the main experience for my users is about the visuals in my app, less so about visuals in Zowie UI. 

Thank you for considering!