### PR TITLE
Add Decision Engine events documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,14 @@ Zowie.shared.set(urlHandler: { url, source in
 })
 ```
 
-### GenAI events
+### Decision Engine events
 
-You can listen for GenAI events triggered from the configured scenario with `Zowie.shared.on(eventName, handler)`.
+You can listen for Decision Engine events triggered from the configured scenario with `Zowie.shared.on(eventName, handler)`.
 
-- `eventName` must match genai event name exactly.
-- `params` is delivered as `Any?` (type depends on what was sent from the GenAI scenario):
+For more information about Decision Engine, see the [Decision Engine API documentation](https://github.com/chatbotizeteam/decission-engine-api#ui).
+
+- `eventName` must match decision engine event name exactly.
+- `params` is delivered as `Any?` (type depends on what was sent from the Decision Engine scenario):
   - JSON object → `[String: Any]`
   - JSON array → `[Any]`
   - plain value / invalid JSON → `String`

--- a/README.md
+++ b/README.md
@@ -177,3 +177,27 @@ Zowie.shared.set(urlHandler: { url, source in
     return false
 })
 ```
+
+### GenAI events
+
+You can listen for GenAI events triggered from the configured scenario with `Zowie.shared.on(eventName, handler)`.
+
+- `eventName` must match genai event name exactly.
+- `params` is delivered as `Any?` (type depends on what was sent from the GenAI scenario):
+  - JSON object → `[String: Any]`
+  - JSON array → `[Any]`
+  - plain value / invalid JSON → `String`
+  - missing value → `nil`
+
+```swift
+Zowie.shared.on("meetingDetails") { [weak self] params in
+    // handle event payload
+    self?.handleMeetingDetails(params)
+}
+```
+
+To remove a handler for a given event, use `off`:
+
+```swift
+Zowie.shared.off("meetingDetails")
+```


### PR DESCRIPTION
## Summary
- Add documentation for Decision Engine events support
- Document `Zowie.shared.on()` and `off()` methods for listening to Decision Engine events
- Include parameter type mappings and usage examples
- Add link to Decision Engine API documentation

## Test plan
Documentation-only change, no code modifications required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)